### PR TITLE
Fix MSA collection and parsing

### DIFF
--- a/bloodhound/ad/utils.py
+++ b/bloodhound/ad/utils.py
@@ -311,18 +311,17 @@ class ADUtils(object):
                 resolved['type'] = 'Base'
         else:
             accountType = ADUtils.get_entry_property(entry, 'sAMAccountType')
+            object_class = ADUtils.get_entry_property(entry, 'objectClass', [])
             if accountType in [268435456, 268435457, 536870912, 536870913]:
                 resolved['type'] = 'Group'
-            elif ADUtils.get_entry_property(entry, 'msDS-GroupMSAMembership', default=b'', raw=True) != b'':
+            elif accountType in [805306368] or \
+                 'msDS-GroupManagedServiceAccount' in object_class or \
+                 'msDS-ManagedServiceAccount' in object_class:
                 resolved['type'] = 'User'
-                short_name = account.rstrip('$')
-                resolved['principal'] = ('%s@%s' % (short_name, domain)).upper()
             elif accountType in [805306369]:
                 resolved['type'] = 'Computer'
                 short_name = account.rstrip('$')
                 resolved['principal'] = ('%s.%s' % (short_name, domain)).upper()
-            elif accountType in [805306368]:
-                resolved['type'] = 'User'
             elif accountType in [805306370]:
                 resolved['type'] = 'trustaccount'
             else:


### PR DESCRIPTION
- Added collection of sMSA.
- Fixed gMSA name when `msDS-GroupMSAMembership` is empty. In that case, it was set to `NAME.CONTOSO.COM`.
    - We must rely on the object classes to detect sMSA and gMSA because `msDS-HostServiceAccountBL` and `ms-DS-GroupMSAMembership` may both be empty. SharpHound collects the MSA even if these properties are empty.
- Removed gMSA samaccountname rstrip of `$` to match SharpHound.
- Removed the collection of MSA as computer objects, which will overwrite the user objects if they are imported as computers afterwards.

You can edit this code however you like.