### PR TITLE
Fix AllowedToDelegate format for Users and Computers (Close #113)

### DIFF
--- a/bloodhound/ad/computer.py
+++ b/bloodhound/ad/computer.py
@@ -33,7 +33,6 @@ from impacket.dcerpc.v5.ndr import NULL
 from impacket.dcerpc.v5.dtypes import RPC_SID, MAXIMUM_ALLOWED
 from bloodhound.ad.utils import ADUtils, AceResolver
 from bloodhound.enumeration.acls import parse_binary_acl
-from bloodhound.enumeration.objectresolver import ObjectResolver
 from bloodhound.ad.structures import LDAP_SID
 from impacket.smb3 import SMB3
 from impacket.smb import SMB

--- a/bloodhound/enumeration/memberships.py
+++ b/bloodhound/enumeration/memberships.py
@@ -30,6 +30,7 @@ from bloodhound.ad.utils import ADUtils, AceResolver
 from bloodhound.ad.computer import ADComputer
 from bloodhound.ad.structures import LDAP_SID
 from bloodhound.enumeration.acls import AclEnumerator, parse_binary_acl
+from bloodhound.enumeration.objectresolver import ObjectResolver
 from bloodhound.enumeration.outputworker import OutputWorker
 
 class MembershipEnumerator(object):
@@ -166,6 +167,7 @@ class MembershipEnumerator(object):
             if with_properties:
                 MembershipEnumerator.add_user_properties(user, entry)
                 if 'allowedtodelegate' in user['Properties']:
+                    delegatehosts_cache = []
                     for host in user['Properties']['allowedtodelegate']:
                         try:
                             target = host.split('/')[1]
@@ -173,11 +175,24 @@ class MembershipEnumerator(object):
                             logging.warning('Invalid delegation target: %s', host)
                             continue
                         try:
-                            sid = self.addomain.computersidcache.get(target.lower())
-                            user['AllowedToDelegate'].append(sid)
+                            object_sid = self.addomain.computersidcache.get(target.lower())
+                            user['AllowedToDelegate'].append({
+                                'ObjectIdentifier': object_sid,
+                                'ObjectType': ADUtils.resolve_ad_entry(
+                                    self.addomain.objectresolver.resolve_sid(object_sid)
+                                )['type'],
+                            })
                         except KeyError:
-                            if '.' in target:
-                                user['AllowedToDelegate'].append(target.upper())
+                            object_sam = target.upper().split(".")[0]
+                            if object_sam in delegatehosts_cache: continue
+                            delegatehosts_cache.append(object_sam)
+                            object_entry = self.addomain.objectresolver.resolve_samname(object_sam + '*', allow_filter=True)
+                            if object_entry:
+                                object_resolved = ADUtils.resolve_ad_entry(object_entry[0])
+                                user['AllowedToDelegate'].append({
+                                    'ObjectIdentifier': object_resolved['objectid'],
+                                    'ObjectType': object_resolved['type'],
+                                })
                 # Parse SID history
                 if len(user['Properties']['sidhistory']) > 0:
                     for historysid in user['Properties']['sidhistory']:

--- a/bloodhound/enumeration/memberships.py
+++ b/bloodhound/enumeration/memberships.py
@@ -30,7 +30,6 @@ from bloodhound.ad.utils import ADUtils, AceResolver
 from bloodhound.ad.computer import ADComputer
 from bloodhound.ad.structures import LDAP_SID
 from bloodhound.enumeration.acls import AclEnumerator, parse_binary_acl
-from bloodhound.enumeration.objectresolver import ObjectResolver
 from bloodhound.enumeration.outputworker import OutputWorker
 
 class MembershipEnumerator(object):

--- a/bloodhound/enumeration/objectresolver.py
+++ b/bloodhound/enumeration/objectresolver.py
@@ -60,13 +60,16 @@ class ObjectResolver(object):
                                                           attributes=['sAMAccountName', 'distinguishedName', 'sAMAccountType', 'objectSid', 'name'])
             return distinguishedname
 
-    def resolve_samname(self, samname, use_gc=True):
+    def resolve_samname(self, samname, use_gc=True, allow_filter=False):
         """
         Resolve a SAM name in the GC. This can give multiple results.
         Returns a list of LDAP entries
         """
         out = []
-        safename = escape_filter_chars(samname)
+        if not allow_filter:
+            safename = escape_filter_chars(samname)
+        else:
+            safename = samname
         with self.lock:
             if use_gc:
                 if not self.addc.gcldap:


### PR DESCRIPTION
As proposed in https://github.com/fox-it/BloodHound.py/issues/113, this PR implements changes in the delegation handling logic in `computer.py` and `memberships.py`. The changes implemented are as follows:

- If the object is referenced by SID (check logic unchanged), the object is resolved via existing method `resolve_sid()`.
- If the object is referenced by another name, it is split and resolved by its samAccountName via `resolve_samname()`.
  - Since we aren't sure of the exact samAccountName (could be `USERNAME` or `COMPUTERNAME$` for example), the `allow_filter` flag was introduced to allow the use of LDAP wildcards in the `resolve_samname()` function.
  - The check for a period (".") in the name has been removed, since this could cause issues in cases where a user (not a FQDN) is allowed to delegate. To avoid duplicates (e.g. "HOST" and "HOST.fqdn" both appearing), a variable called `delegatehosts_cache` is introduced to keep track of hosts that have already been processed.
- After resolving the object, the `resolve_ad_entry()` function is used to get the object's properties. If a samAccountName was used before, the resolved object properties are used to translate that back to its `objectID`.

Tested to work in my environment. Also tested with the latest version of `bloodhound_import` (https://github.com/fox-it/bloodhound-import/commit/d52c24fbdc95d0fd2c125b6468dc897c08eae939), closing referencing PR https://github.com/fox-it/bloodhound-import/pull/37.

![image](https://user-images.githubusercontent.com/25614522/217557784-0ff5d04c-f5fd-4068-aa81-5968b0035ef4.png)
