### PR TITLE
fixed Crypto ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='bloodhound',
                 'bloodhound.lib',
                 'bloodhound.enumeration'],
       license='MIT',
-      install_requires=['dnspython', 'impacket>=0.9.17', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'pyasn1>=0.4', 'future'],
+      install_requires=['dnspython', 'impacket>=0.9.17', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'pycryptodome', 'pyasn1>=0.4', 'future'],
       classifiers=[
         'Intended Audience :: Information Technology',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Fixed ModuleNotFoundError: No module named 'Crypto'.

Installing 'pycryptodome' module fixes the error..