### PR TITLE
Default domain arg to '' instead of None

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -221,6 +221,7 @@ def main():
     parser.add_argument('-d',
                         '--domain',
                         action='store',
+                        default='',
                         help='Domain to query.')
     parser.add_argument('-dc',
                         '--domain-controller',


### PR DESCRIPTION
The calls to ADAuthentication in file init.py lines previously were passing None if -d was not specified, leading to a crash when trying to convert None to lowercase. Defaulted to '' as the ADAuthentication function is expecting