### PR TITLE
Added LDAP Channel Binding Support

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -258,6 +258,9 @@ def main():
     coopts.add_argument('--cachefile',
                         action='store',
                         help='Cache file (experimental)')
+    coopts.add_argument('--ldap-channel-binding',
+                        action='store_true',
+                        help='Use LDAP Channel Binding (will force ldaps protocol to be used)')
 
 
     args = parser.parse_args()
@@ -267,10 +270,10 @@ def main():
 
     if args.username is not None and args.password is not None:
         logging.debug('Authentication: username/password')
-        auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method)
+        auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
     elif args.username is not None and args.password is None and args.hashes is None:
         args.password = getpass.getpass()
-        auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method)
+        auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
     elif args.username is None and (args.password is not None or args.hashes is not None):
         logging.error('Authentication: password or hashes provided without username')
         sys.exit(1)
@@ -278,19 +281,19 @@ def main():
         if args.hashes:
             logging.debug('Authentication: NT hash')
             lm, nt = args.hashes.split(":")
-            auth = ADAuthentication(lm_hash=lm, nt_hash=nt, username=args.username, domain=args.domain, auth_method=args.auth_method)
+            auth = ADAuthentication(lm_hash=lm, nt_hash=nt, username=args.username, domain=args.domain, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
             if args.aesKey:
                 logging.debug('Authentication: Kerberos AES')
                 auth.set_aeskey(args.aesKey)
         else:
             logging.debug('Authentication: Kerberos AES')
-            auth = ADAuthentication(username=args.username, domain=args.domain, aeskey=args.aesKey, auth_method=args.auth_method)
+            auth = ADAuthentication(username=args.username, domain=args.domain, aeskey=args.aesKey, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
     else:
         if not args.kerberos:
             parser.print_help()
             sys.exit(1)
         else:
-            auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method)
+            auth = ADAuthentication(username=args.username, password=args.password, domain=args.domain, auth_method=args.auth_method, ldap_channel_binding=args.ldap_channel_binding)
 
     ad = AD(auth=auth, domain=args.domain, nameserver=args.nameserver, dns_tcp=args.dns_tcp, dns_timeout=args.dns_timeout)
 

--- a/bloodhound/ad/authentication.py
+++ b/bloodhound/ad/authentication.py
@@ -27,8 +27,9 @@ import os
 import traceback
 from bloodhound.ad.utils import CollectionException
 from binascii import unhexlify
-from ldap3 import Server, Connection, NTLM, ALL, SASL, KERBEROS
+from ldap3 import Server, Connection, NTLM, ALL, SASL, KERBEROS, Tls
 from ldap3.core.results import RESULT_STRONGER_AUTH_REQUIRED
+import ldap3
 from ldap3.operation.bind import bind_operation
 from impacket.krb5.ccache import CCache
 from impacket.krb5.types import Principal, KerberosTime, Ticket
@@ -46,7 +47,7 @@ Active Directory authentication helper
 """
 class ADAuthentication(object):
     def __init__(self, username='', password='', domain='',
-                 lm_hash='', nt_hash='', aeskey='', kdc=None, auth_method='auto'):
+                 lm_hash='', nt_hash='', aeskey='', kdc=None, auth_method='auto', ldap_channel_binding=False):
         self.username = username
         # Assume user domain and enum domain are same
         self.domain = domain.lower()
@@ -63,6 +64,7 @@ class ADAuthentication(object):
         # KDC for domain of the user - fill with domain first, will be resolved later
         self.userdomain_kdc = self.domain
         self.auth_method = auth_method
+        self.ldap_channel_binding = ldap_channel_binding
 
         # Kerberos
         self.tgt = None
@@ -74,21 +76,58 @@ class ADAuthentication(object):
     def getLDAPConnection(self, hostname='', ip='', baseDN='', protocol='ldaps', gc=False):
         if gc:
             # Global Catalog connection
-            if protocol == 'ldaps':
-                # Ldap SSL
-                server = Server("%s://%s:3269" % (protocol, ip), get_info=ALL)
+            if protocol == 'ldaps' or self.ldap_channel_binding is True:
+                if self.ldap_channel_binding is True:
+                    if not hasattr(ldap3, 'TLS_CHANNEL_BINDING'):
+                        raise Exception("To use LDAP channel binding, install the patched ldap3 module: pip3 install git+https://github.com/ly4k/ldap3")
+                    logging.debug("Using LDAPS channel binding")
+                    protocol = 'ldaps'
+                    import ssl
+                    version=ssl.PROTOCOL_TLSv1_2
+                    tls = Tls(validate=ssl.CERT_NONE, version=version, ciphers='ALL:@SECLEVEL=0')
+                    server = Server(
+                        "%s://%s:3269" % (protocol,ip),
+                        use_ssl=True,
+                        get_info=ALL,
+                        tls=tls
+                    )
+                else:
+                    # Ldap SSL (no channel binding)
+                    server = Server("%s://%s:3269" % (protocol, ip), get_info=ALL)
             else:
                 # Plain LDAP
                 server = Server("%s://%s:3268" % (protocol, ip), get_info=ALL)
-        else:
-            server = Server("%s://%s" % (protocol, ip), get_info=ALL)
+        else: # no GC specified
+            if self.ldap_channel_binding is True:
+                if not hasattr(ldap3, 'TLS_CHANNEL_BINDING'):
+                    raise Exception("To use LDAP channel binding, install the patched ldap3 module: pip3 install git+https://github.com/ly4k/ldap3")
+                logging.debug("Using LDAPS channel binding")
+                import ssl
+                protocol = 'ldaps'
+                version=ssl.PROTOCOL_TLSv1_2
+                tls = Tls(validate=ssl.CERT_NONE, version=version, ciphers='ALL:@SECLEVEL=0')
+                server = Server(
+                    "%s://%s" % (protocol,ip),
+                    use_ssl=True,
+                    get_info=ALL,
+                    tls=tls
+                )
+            else: # No LDAP Channel Binding
+                server = Server("%s://%s" % (protocol, ip), get_info=ALL)
         # ldap3 supports auth with the NT hash. LM hash is actually ignored since only NTLMv2 is used.
         if self.nt_hash != '':
             ldappass = self.lm_hash + ':' + self.nt_hash
         else:
             ldappass = self.password
         ldaplogin = '%s\\%s' % (self.userdomain, self.username)
-        conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM, receive_timeout=60, auto_range=True)
+        if self.ldap_channel_binding:
+            from ldap3 import TLS_CHANNEL_BINDING
+            logging.debug("Using LDAPS channel binding")
+            protocol = 'ldaps'
+            channel_binding = {"channel_binding": TLS_CHANNEL_BINDING}
+            conn = Connection(server, user=ldaplogin, password=ldappass, authentication=NTLM, auto_referrals=False, **channel_binding)
+        else:
+            conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM, receive_timeout=60, auto_range=True)
         bound = False
         if self.tgt is not None and self.auth_method in ('kerberos', 'auto'):
             conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=SASL, sasl_mechanism=KERBEROS)
@@ -104,18 +143,22 @@ class ADAuthentication(object):
                     logging.debug('Kerberos auth to LDAP failed, no authentication methods left')
 
         if not bound:
-            conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM)
             logging.debug('Authenticating to LDAP server with NTLM')
             bound = conn.bind()
 
         if not bound:
             result = conn.result
+            if result['result'] == RESULT_STRONGER_AUTH_REQUIRED and protocol == 'ldaps':
+                logging.warning('LDAP Authentication is refused because LDAP Channel Binding is likely enabled. '
+                                'Trying to connect using LDAP Channel Binding')
+                self.ldap_channel_binding = True
+                return self.getLDAPConnection(hostname, ip, baseDN, 'ldaps')
             if result['result'] == RESULT_STRONGER_AUTH_REQUIRED and protocol == 'ldap':
                 logging.warning('LDAP Authentication is refused because LDAP signing is enabled. '
                                 'Trying to connect over LDAPS instead...')
                 return self.getLDAPConnection(hostname, ip, baseDN, 'ldaps')
             else:
-                logging.error('Failure to authenticate with LDAP! Error %s' % result['message'])
+                logging.error('Failure to authenticate with LDAP! Error %s : Code: %s' % (result['message'], result['result']))
                 raise CollectionException('Could not authenticate to LDAP. Check your credentials and LDAP server requirements.')
         return conn
 

--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -54,7 +54,7 @@ class ADDC(ADComputer):
         # Initialize GUID map
         self.objecttype_guid_map = dict()
 
-    def ldap_connect(self, protocol='ldap', resolver=False):
+    def ldap_connect(self, protocol='ldaps', resolver=False):
         """
         Connect to the LDAP service
         """


### PR DESCRIPTION
1. Added ldap channel binding
2. Set the default protocol in domain.py to match that of authentication.py 
3. Removed a line in authentication.py that recreates the conn variable before binding which seemed unnecessary

Once added, I was able to fully enumerate a domain with ldap channel signing enforced as intended.
Maybe double check the removal of line 107 of bloodhound/ad/authentication.py where I got rid of the "additional" `conn` variable creation. It seemed redundant, but you be the judge. If it needs to stay then the ldap channel binding arg needs to be passed there as well. 