### PR TITLE
Allow authentication when LM hash is empty

### DIFF
--- a/bloodhound/ad/authentication.py
+++ b/bloodhound/ad/authentication.py
@@ -90,7 +90,11 @@ class ADAuthentication(object):
             server = Server("%s://%s" % (protocol, ip), get_info=ALL)
         # ldap3 supports auth with the NT hash. LM hash is actually ignored since only NTLMv2 is used.
         if self.nt_hash != '':
-            ldappass = self.lm_hash + ':' + self.nt_hash
+            if self.lm_hash != '':
+                ldappass = self.lm_hash + ':' + self.nt_hash
+            else:
+                # ldap3 requires a 32-character long string for LM hash in order to use the NT hash
+                ldappass = 'aad3b435b51404eeaad3b435b51404ee:' + self.nt_hash
         else:
             ldappass = self.password
         ldaplogin = '%s\\%s' % (self.userdomain, self.username)


### PR DESCRIPTION
It would be great to allow authentication when the `-hashes` parameter only contains the NT hash such as `:8846f7eaee8fb117ad06bdd830b7586c`.
This PR implements a simple fix that checks whether the LM hash is empty, and in that case, it replaces it with the LM hash of the empty string.

A note on `ldap3`: we can basically use an arbitrary 32-character long string for this hash since it does not use it anyway as long as it has the proper length. From ldap3:
```python3
def ntowf_v2(self):
    passparts = self._password.split(':')
    if len(passparts) == 2 and len(passparts[0]) == 32 and len(passparts[1]) == 32:    # <-- STILL NEEDS A 32-CHARACTER LONG LM VALUE TO USE THE NT HASH
        # The specified password is an LM:NTLM hash
        password_digest = binascii.unhexlify(passparts[1])    # <-- ONLY USES NT HASH ANYWAY
    else:
        try:
            password_digest = hashlib.new('MD4', self._password.encode('utf-16-le')).digest()
        except ValueError as e:
            try:
                from Crypto.Hash import MD4  # try with the Crypto library if present
                password_digest = MD4.new(self._password.encode('utf-16-le')).digest()
            except ImportError:
                raise e  # raise original exception

    return hmac.new(password_digest, (self.user_name.upper() + self.user_domain).encode('utf-16-le'), digestmod=hashlib.md5).digest()
```

If the length is different from 32 bytes however, it will compute the NT hash of the string provided and therefore will try to authenticate with wrong credentials.
