### PR TITLE
Additional Organizational Units ACLs

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -40,7 +40,7 @@ EXTRIGHTS_GUID_MAPPING = {
     "UserForceChangePassword": string_to_bin("00299570-246d-11d0-a768-00aa006e0529"),
     "AllowedToAct": string_to_bin("3f78c3e5-f79a-46bd-a0b8-9d18116ddc79"),
     "UserAccountRestrictionsSet": string_to_bin("4c164200-20c0-11d0-a768-00aa006e0529"),
-    "ManageGPLink": string_to_bin("f30e3bbf-9ff0-11d1-b603-0000f80367c1")
+    "WriteGPLink": string_to_bin("f30e3bbf-9ff0-11d1-b603-0000f80367c1")
 }
 
 def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
@@ -142,8 +142,8 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
                 # Property set, but ignore Domain Admins since they already have enough privileges anyway
                 if entrytype == 'computer' and can_write_property(ace_object, EXTRIGHTS_GUID_MAPPING['UserAccountRestrictionsSet']) and not sid.endswith('-512'):
                     relations.append(build_relation(sid, 'WriteAccountRestrictions', '', inherited=is_inherited))
-                if entrytype == 'organizational-unit' and can_write_property(ace_object, EXTRIGHTS_GUID_MAPPING['ManageGPLink']):
-                    relations.append(build_relation(sid, 'ManageGPLink', '', inherited=is_inherited))
+                if entrytype == 'organizational-unit' and can_write_property(ace_object, EXTRIGHTS_GUID_MAPPING['WriteGPLink']):
+                    relations.append(build_relation(sid, 'WriteGPLink', '', inherited=is_inherited))
 
 
                 # Since 4.0

--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -39,7 +39,8 @@ EXTRIGHTS_GUID_MAPPING = {
     "WriteMember": string_to_bin("bf9679c0-0de6-11d0-a285-00aa003049e2"),
     "UserForceChangePassword": string_to_bin("00299570-246d-11d0-a768-00aa006e0529"),
     "AllowedToAct": string_to_bin("3f78c3e5-f79a-46bd-a0b8-9d18116ddc79"),
-    "UserAccountRestrictionsSet": string_to_bin("4c164200-20c0-11d0-a768-00aa006e0529")
+    "UserAccountRestrictionsSet": string_to_bin("4c164200-20c0-11d0-a768-00aa006e0529"),
+    "ManageGPLink": string_to_bin("f30e3bbf-9ff0-11d1-b603-0000f80367c1")
 }
 
 def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
@@ -132,7 +133,7 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
             writeprivs = ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_WRITE_PROP)
             if writeprivs:
                 # GenericWrite
-                if entrytype in ['user', 'group', 'computer', 'gpo'] and not ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT):
+                if entrytype in ['user', 'group', 'computer', 'gpo', 'organizational-unit'] and not ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT):
                     relations.append(build_relation(sid, 'GenericWrite', inherited=is_inherited))
                 if entrytype == 'group' and can_write_property(ace_object, EXTRIGHTS_GUID_MAPPING['WriteMember']):
                     relations.append(build_relation(sid, 'AddMember', '', inherited=is_inherited))
@@ -141,6 +142,8 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
                 # Property set, but ignore Domain Admins since they already have enough privileges anyway
                 if entrytype == 'computer' and can_write_property(ace_object, EXTRIGHTS_GUID_MAPPING['UserAccountRestrictionsSet']) and not sid.endswith('-512'):
                     relations.append(build_relation(sid, 'WriteAccountRestrictions', '', inherited=is_inherited))
+                if entrytype == 'organizational-unit' and can_write_property(ace_object, EXTRIGHTS_GUID_MAPPING['ManageGPLink']):
+                    relations.append(build_relation(sid, 'ManageGPLink', '', inherited=is_inherited))
 
 
                 # Since 4.0
@@ -200,7 +203,7 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
 
             if mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_WRITE_PROP):
                 # Genericwrite is only for properties, don't skip after
-                if entrytype in ['user', 'group', 'computer', 'gpo']:
+                if entrytype in ['user', 'group', 'computer', 'gpo', 'organizational-unit']:
                     relations.append(build_relation(sid, 'GenericWrite', inherited=is_inherited))
 
             if mask.has_priv(ACCESS_MASK.WRITE_OWNER):


### PR DESCRIPTION
This pull request adds the collection of two ACLs related to Organizational Units: **GenericWrite** and **Manage Group Policy Links**.
The motivation behind the pull request is described in the following article: https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory

A similar pull request was created for the C# collector SharpHound. An additional pull request was created for the BloodHound GUI, in order to create two new edges associated with the GenericWrite and Manage Group Policy Links OU ACLs.