### PR TITLE
[bug-fix] Function get_entry_property() is not expecting a None entry, leading to TypeError: 'NoneType' object is not subscriptable

### DIFF
--- a/bloodhound/ad/utils.py
+++ b/bloodhound/ad/utils.py
@@ -355,6 +355,8 @@ class ADUtils(object):
         converting empty values to the default specified. This is primarily
         for output to JSON
         """
+        if entry is None:
+            return default
         try:
             if raw:
                 value = entry['raw_attributes'][prop]


### PR DESCRIPTION
Hi,

I found a bug in the `get_entry_property` function when a `NoneType` entry is passed:

```
# ./bloodhound.py --zip -c All -d "$DOMAIN" -u "$USER" -p "$PASSWORD" -dc "$DC_HOST" --use-ldaps
INFO: Found AD domain: LAB.local
WARNING: Could not find a global catalog server, assuming the primary DC has this role
If this gives errors, either specify a hostname with -gc or disable gc resolution with --disable-autogc
INFO: Getting TGT for user
INFO: Connecting to LDAP server: DC01.LAB.local
INFO: Found 1 domains
INFO: Found 1 domains in the forest
INFO: Found 2156 computers
INFO: Connecting to GC LDAP server: DC01.LAB.local
WARNING: LDAP Authentication is refused because LDAP signing is enabled. Trying to connect over LDAPS instead...
INFO: Connecting to LDAP server: DC01.LAB.local
Traceback (most recent call last):
  File "/tmp/BloodHound.py/./bloodhound.py", line 5, in <module>
    bloodhound.main()
  File "/tmp/BloodHound.py/bloodhound/__init__.py", line 343, in main
    bloodhound.run(collect=collect,
  File "/tmp/BloodHound.py/bloodhound/__init__.py", line 81, in run
    membership_enum.enumerate_memberships(timestamp=timestamp, fileNamePrefix=fileNamePrefix)
  File "/tmp/BloodHound.py/bloodhound/enumeration/memberships.py", line 844, in enumerate_memberships
    self.enumerate_users(timestamp, fileNamePrefix)
  File "/tmp/BloodHound.py/bloodhound/enumeration/memberships.py", line 183, in enumerate_users
    'ObjectType': ADUtils.resolve_ad_entry(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/BloodHound.py/bloodhound/ad/utils.py", line 278, in resolve_ad_entry
    account = ADUtils.get_entry_property(entry, 'sAMAccountName', '')
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/BloodHound.py/bloodhound/ad/utils.py", line 362, in get_entry_property
    value = entry['attributes'][prop]
            ~~~~~^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

The problem takes its source here, the SID resolution can return `None`:

![image](https://github.com/dirkjanm/BloodHound.py/assets/79218792/ddcc1299-a14e-4818-9614-7fa063e652f2)

Then the value cascades into the `resolve_ad_entry()` function, which calls `get_entry_property()`. As `get_entry_property()` is not expecting a `None` entry, it crashes and breaks the whole process.

Fixed in this pull request

Best regards,