### PR TITLE
-user-domain and WriteSPN not showing

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -133,6 +133,7 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
             # Property write privileges
             writeprivs = ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_WRITE_PROP)
             if writeprivs:
+
                 # GenericWrite
                 if entrytype in ['user', 'group', 'computer', 'gpo'] and not ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT):
                     relations.append(build_relation(sid, 'GenericWrite', inherited=is_inherited))
@@ -151,8 +152,14 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
                 and 'ms-ds-key-credential-link' in objecttype_guid_map and ace_object.acedata.get_object_type().lower() == objecttype_guid_map['ms-ds-key-credential-link']:
                     relations.append(build_relation(sid, 'AddKeyCredentialLink', inherited=is_inherited))
 
+                #Old WriteSPN query, for some reason saying that the if needs to have a entrytype of 'user' can lead to false positives and do not return that a user have write spn over a computer
                 # ServicePrincipalName property write rights (exclude generic rights)
-                if entrytype == 'user' and ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) \
+                #if entrytype == 'user' and ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) \
+                #and ace_object.acedata.get_object_type().lower() == objecttype_guid_map['service-principal-name']:
+                #    relations.append(build_relation(sid, 'WriteSPN', inherited=is_inherited))
+
+                # ServicePrincipalName property write rights (exclude generic rights)
+                if ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) \
                 and ace_object.acedata.get_object_type().lower() == objecttype_guid_map['service-principal-name']:
                     relations.append(build_relation(sid, 'WriteSPN', inherited=is_inherited))
 


### PR DESCRIPTION
I don't know If there is already a fix/pr for this but when I was trying to do the offshore pro lab from htb sometimes I had a account from domain dev.admin but wanted to query at admin, since there was a bidirectional trust a account from dev works on admin. The problem is the code right now gets the domain from the -d which is used for queries and thinks this is the domain from the user you are trying to auth, sometimes this is not true so a new options -user-domain is added.

If -user-domain is not present bloodhound acts like it is right now, grabs the domain from -d and start the script, if -user-domain is present It will use that as the domain of the user. For example I got a user named test from dev.admin domain and want to query at the dc02 from admin domain, using the test account. -user-domain dev.admin -u test will resolve the issue

The second one from my tests everything is working fine but since I'm not yet 100% sure I decided to push this to this branch instead of master (although the same changes from this branch are present on master branch on my fork).

For some reason at acls.py checking WriteSPNS entrytype == 'user' lead to false positives and never showed up that a user have writespn over a computer for example, this commit remove this check and everything works fine.