### PR TITLE
Add custom port option

### DIFF
--- a/bloodhound/ad/utils.py
+++ b/bloodhound/ad/utils.py
@@ -169,7 +169,7 @@ class ADUtils(object):
         binding = r'ncacn_np:%s[\PIPE\wkssvc]' % ip
         rpctransportWkst = transport.DCERPCTransportFactory(binding)
         if hasattr(rpctransportWkst, 'set_credentials'):
-            rpctransportWkst.set_credentials(adauth.username, adauth.password, 
+            rpctransportWkst.set_credentials(adauth.username, adauth.password,
                                 adauth.domain, adauth.lm_hash, adauth.nt_hash, adauth.aes_key)
             rpctransportWkst.set_kerberos(False, adauth.kdc) # not supported yet
         dce = rpctransportWkst.get_dce_rpc()
@@ -207,7 +207,7 @@ class ADUtils(object):
                     result = '.'.join((result, info['dns_domain']))
                 return result.lower()
             return None
-        
+
         try:
             ntlm_dumper = DumpNtlm(ip, ip, 445)
             hostname = parse_info(ntlm_dumper.GetInfo())
@@ -592,4 +592,7 @@ class SamCache(SidCache):
     pass
 
 class CollectionException(Exception):
+    pass
+
+class ConnectionException(Exception):
     pass


### PR DESCRIPTION
There are some alternative implementations for LDAP, i.e. Univention, which might use a port different than default.
This adds an option to specify a custom port.