### PR TITLE
add detailed os version collection

### DIFF
--- a/bloodhound/ad/computer.py
+++ b/bloodhound/ad/computer.py
@@ -166,11 +166,16 @@ class ADComputer(object):
             props['whencreated'] = whencreated
             props['serviceprincipalnames'] = ADUtils.get_entry_property(entry, 'servicePrincipalName', [])
             props['description'] = ADUtils.get_entry_property(entry, 'description')
-            props['operatingsystem'] = ADUtils.get_entry_property(entry, 'operatingSystem')
+
+            osname = ADUtils.get_entry_property(entry, 'operatingSystem')
+            osservicepack = ADUtils.get_entry_property(entry, 'operatingSystemServicePack')
+            osversion = ADUtils.get_entry_property(entry, 'operatingSystemVersion')
             # Add SP to OS if specified
-            servicepack = ADUtils.get_entry_property(entry, 'operatingSystemServicePack')
-            if servicepack:
-                props['operatingsystem'] = '%s %s' % (props['operatingsystem'], servicepack)
+            props['operatingsystem'] = '%s %s' % (osname, osservicepack) if osservicepack else osname
+            props['operatingsystemname'] = osname
+            props['operatingsystemservicepack'] = osservicepack
+            props['operatingsystemversion'] = osversion
+
             props['sidhistory'] = [LDAP_SID(bsid).formatCanonical() for bsid in ADUtils.get_entry_property(entry, 'sIDHistory', [])]
             delegatehosts = ADUtils.get_entry_property(entry, 'msDS-AllowedToDelegateTo', [])
             delegatehosts_cache = []

--- a/bloodhound/ad/domain.py
+++ b/bloodhound/ad/domain.py
@@ -479,7 +479,7 @@ class ADDC(ADComputer):
         if include_properties:
             properties += ['servicePrincipalName', 'msDS-AllowedToDelegateTo', 'sIDHistory', 'whencreated',
                            'lastLogon', 'lastLogonTimestamp', 'pwdLastSet', 'operatingSystem', 'description',
-                           'operatingSystemServicePack']
+                           'operatingSystemServicePack', 'operatingSystemVersion']
             # Difference between guid map which maps the lowercase schema object name and the property name itself
             if 'ms-DS-Allowed-To-Act-On-Behalf-Of-Other-Identity'.lower() in self.objecttype_guid_map:
                 properties.append('msDS-AllowedToActOnBehalfOfOtherIdentity')


### PR DESCRIPTION
With this PR the additional computer attribute *operatingSystemVersion* is collected from LDAP.
Furthermore the computer object in BloodHound gets the three additional attributes *operatingsystemname*, *operatingsystemservicepack* and *operatingsystemversion* that reflect the values of the respective LDAP attributes. The value of the original *operatingsystem* attribute in BloodHound remains unchanged.
This enables detailed reporting on outdated Windows versions, e.g. unsupported Windows 10 builds.