### PR TITLE
Exclude disabled gpLink

### DIFF
--- a/bloodhound/enumeration/domains.py
+++ b/bloodhound/enumeration/domains.py
@@ -155,14 +155,15 @@ class DomainEnumerator(object):
 
 
         if 'container' in collect:
-            for gplink_dn, options in ADUtils.parse_gplink_string(ADUtils.get_entry_property(domain_object, 'gPLink', '')):
-                link = dict()
-                link['IsEnforced'] = options == 2
-                try:
-                    link['GUID'] = self.addomain.get_dn_from_cache_or_ldap(gplink_dn.upper())['ObjectIdentifier']
-                    domain['Links'].append(link)
-                except TypeError:
-                    logging.warning('Could not resolve GPO link to {0}'.format(gplink_dn))
+            for gplink_dn, option in ADUtils.parse_gplink_string(ADUtils.get_entry_property(domain_object, 'gPLink', '')):
+                if option == 0 or option == 2:
+                    link = dict()
+                    link['IsEnforced'] = option == 2
+                    try:
+                        link['GUID'] = self.addomain.get_dn_from_cache_or_ldap(gplink_dn.upper())['ObjectIdentifier']
+                        domain['Links'].append(link)
+                    except TypeError:
+                        logging.warning('Could not resolve GPO link to {0}'.format(gplink_dn))
 
         # Single domain only
         datastruct['meta']['count'] = 1

--- a/bloodhound/enumeration/memberships.py
+++ b/bloodhound/enumeration/memberships.py
@@ -570,14 +570,15 @@ class MembershipEnumerator(object):
                 }
                 ou["ChildObjects"].append(out_object)
             
-            for gplink_dn, options in ADUtils.parse_gplink_string(ADUtils.get_entry_property(entry, 'gPLink', '')):
-                link = dict()
-                link['IsEnforced'] = options == 2
-                try:
-                    link['GUID'] = self.get_membership(gplink_dn.upper())['ObjectIdentifier']
-                    ou['Links'].append(link)
-                except TypeError:
-                    logging.warning('Could not resolve GPO link to {0}'.format(gplink_dn))
+            for gplink_dn, option in ADUtils.parse_gplink_string(ADUtils.get_entry_property(entry, 'gPLink', '')):
+                if option == 0 or option == 2:
+                    link = dict()
+                    link['IsEnforced'] = option == 2
+                    try:
+                        link['GUID'] = self.get_membership(gplink_dn.upper())['ObjectIdentifier']
+                        ou['Links'].append(link)
+                    except TypeError:
+                        logging.warning('Could not resolve GPO link to {0}'.format(gplink_dn))
             
             # Create cache entry for links
             link_output = {


### PR DESCRIPTION
### Exclude Disabled gpLink

Hi,

I'm working on a tool that analyzes GPOs using BloodHound data and SYSVOL. I successfully reconstructed group policy inheritance based on Neo4j data. However, I noticed that the BloodHound collector does not account for disabled GPO links.

This quick fix ensures that disabled GPO links are excluded from being added to the container.

Let me know if you have any questions.