### PR TITLE
Fix: broken ReadLAPSPassword edge

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -161,11 +161,16 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
                     relations.append(build_relation(sid, 'AddSelf', '', inherited=is_inherited))
 
             # Property read privileges
-            if ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_READ_PROP):
+            if ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_READ_PROP) and \
+                ace_object.acedata.mask.has_priv(ACCESS_MASK.ADS_RIGHT_DS_CONTROL_ACCESS):
                 if entrytype == 'computer' and \
                 ace_object.acedata.has_flag(ACCESS_ALLOWED_OBJECT_ACE.ACE_OBJECT_TYPE_PRESENT) and \
                 entry['Properties']['haslaps']:
-                    if ace_object.acedata.get_object_type().lower() in (objecttype_guid_map.get('ms-mcs-admpwd'), objecttype_guid_map.get('mslaps-password')):
+                    if ace_object.acedata.get_object_type().lower() in (
+                        objecttype_guid_map.get("ms-mcs-admpwd"),
+                        objecttype_guid_map.get("ms-laps-password"),
+                        objecttype_guid_map.get("ms-laps-encryptedpassword"),
+                    ):
                         relations.append(build_relation(sid, 'ReadLAPSPassword', inherited=is_inherited))
 
             # Extended rights


### PR DESCRIPTION
Hi Dirk-jan, hope you're doing well.
I found 2 issues with LAPS on bloodhound.py:
#### 1. ReadLAPSPassword for LAPSv2 name vs ldapDisplayName attribute field
* I noticed this after I gave users rights to read LAPS password, but it didn't show up on bloodhound

![image](https://github.com/user-attachments/assets/7049a936-6f7e-493a-8ff7-131a9ba7e42e)


* In `acls.py`, the ObjectType (the schema object `schemaIDGUID`) is retrieve from the dictionnary `get_objecttype`:
```python
        sresult = self.ldap.extend.standard.paged_search(self.ldap.server.info.other['schemaNamingContext'][0],
                                                         '(objectClass=*)',
                                                         attributes=['name', 'schemaidguid'])
```
This retrieves attributes' **name** and GUID.
* However, in `acls.py`, the key used to search in the dictionary is the **ldapDisplayName** (`msLAPS-Password`), for Windows LAPS/LAPSv2, the name and ldapDisplayName are not similar:
![image](https://github.com/user-attachments/assets/e0eda688-c771-4d2c-80e0-dc88bd584bae)
Although they're similar in Legacy LAPS:
![image](https://github.com/user-attachments/assets/c2943f87-e095-40bb-a509-406e870c146b)

* Easily fixed by changing the key to check to the attribute's name  (`ms-LAPS-Password`)  

* I also added `msLAPS-EncryptedPassword` to the list of object types to check

Notes:
* This could also have been fixed by retrieving the `ldapDisplayName` from the ldap query, not sure if one makes more sense than the other.
* For `msLAPS-EncryptedPassword`, the only way we can be sure which of unencrypted or encrypted password is used, is either to check which LDAP attribute is populated, or maybe check the LAPS GPO applied to retrieve the value of ADPasswordEncryptionEnabled (if BackupDirectory is 2), but I'm not sure how that would work out.
* The rest of the code correctly uses the `ldapDisplayName` for password and expiration LDAP attributes. 

And the users show up!

![image](https://github.com/user-attachments/assets/f357e686-67ee-40bf-8f29-e32c20dbade1)

#### 2. acls.py uses an incomplete ACE mask to check for ReadLAPSPassword relation

* After checking the users, I was bugged since a fake Read LAPS holder was found, this is the ACE for my three users:
![image](https://github.com/user-attachments/assets/80fadab9-54e3-432d-94a0-17350eba3a66)

* Since both `ms-msc-admpwd` and `ms-laps-password` are [confidential LDAP attributes](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/mark-attribute-as-confidential), both `Read Property` and `Access Control` ACE's access mask are needed.

* Easily fixed by adding `ACCESS_MASK.ADS_RIGHT_DS_CONTROL_ACCESS` in the checks
 
 And finally, all good!
 
![image](https://github.com/user-attachments/assets/de0bda40-0146-44f0-a7a9-6e883c955192)

Cheers