### PR TITLE
LDAP simple auth option added

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -206,10 +206,10 @@ def main():
                         metavar="hex key",
                         help='AES key to use for Kerberos Authentication (128 or 256 bits)')
     auopts.add_argument('--auth-method',
-                        choices=('auto','ntlm','kerberos'),
+                        choices=('auto','simple','ntlm','kerberos'),
                         default='auto',
                         action='store',
-                        help='Authentication methods. Force Kerberos or NTLM only or use auto for Kerberos with NTLM fallback')
+                        help='Authentication methods. Force Kerberos, NTLM or SIMPLE only or use auto for Kerberos with NTLM and SIMPLE auth fallback')
     coopts = parser.add_argument_group('collection options')
     coopts.add_argument('-ns',
                         '--nameserver',


### PR DESCRIPTION
This MR adds the SIMPLE auth LDAP method to the allowed connection methods.
It can be used directly with the "--auth-method simple" option or as automatic fallback if NTLM auth fails.
It uses the ldap3 "Connection" class just like the other auth methods.
This can be useful when neither Kerberos nor NTLM protocols are available (rare but possible).
Documentation may need to be updated to show the new option for "--auth-method".