### PR TITLE
LDAP simple auth option added

### DIFF
--- a/bloodhound/__init__.py
+++ b/bloodhound/__init__.py
@@ -206,10 +206,10 @@ def main():
                         metavar="hex key",
                         help='AES key to use for Kerberos Authentication (128 or 256 bits)')
     auopts.add_argument('--auth-method',
-                        choices=('auto','ntlm','kerberos'),
+                        choices=('auto','simple','ntlm','kerberos'),
                         default='auto',
                         action='store',
-                        help='Authentication methods. Force Kerberos or NTLM only or use auto for Kerberos with NTLM fallback')
+                        help='Authentication methods. Force Kerberos, NTLM or SIMPLE only or use auto for Kerberos with NTLM and SIMPLE auth fallback')
     coopts = parser.add_argument_group('collection options')
     coopts.add_argument('-ns',
                         '--nameserver',

--- a/bloodhound/ad/authentication.py
+++ b/bloodhound/ad/authentication.py
@@ -33,7 +33,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 import ldap3
-from ldap3 import Server, Connection, NTLM, ALL, SASL, KERBEROS, Tls
+from ldap3 import Server, Connection, SIMPLE, NTLM, ALL, SASL, KERBEROS, Tls
 from ldap3.core.results import RESULT_STRONGER_AUTH_REQUIRED
 from ldap3.operation.bind import bind_operation
 from impacket.krb5.ccache import CCache
@@ -150,7 +150,7 @@ class ADAuthentication(object):
                     logging.debug(traceback.format_exc())
                     logging.critical('Kerberos auth to LDAP failed, no authentication methods left')
                     raise CollectionException('Could not authenticate to LDAP. Check your credentials and LDAP server requirements.')
-        if not bound:
+        if not bound and self.auth_method in ('ntlm', 'auto'):
             conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM, receive_timeout=60, auto_range=True)
             logging.debug('Authenticating to LDAP server with NTLM')
             if self.ldap_channel_binding:
@@ -161,6 +161,13 @@ class ADAuthentication(object):
                 conn = Connection(server, user=ldaplogin, password=ldappass, authentication=NTLM, auto_referrals=False, receive_timeout=60, auto_range=True, **channel_binding)
             else:
                 conn = Connection(server, user=ldaplogin, auto_referrals=False, password=ldappass, authentication=NTLM, receive_timeout=60, auto_range=True)
+            bound = conn.bind()
+
+        if not bound and self.auth_method in ('simple', 'auto'):
+            if self.auth_method == 'auto': logging.warning('NTLM auth to LDAP failed, trying SIMPLE')
+            user_upn = f"{self.username}@{self.domain}"
+            conn = Connection(server, user=user_upn, auto_referrals=False, password=ldappass, authentication=SIMPLE, receive_timeout=60, auto_range=True)
+            logging.debug('Authenticating to LDAP server with SIMPLE auth')
             bound = conn.bind()
 
         if not bound:


### PR DESCRIPTION
This MR adds the SIMPLE auth LDAP method to the allowed connection methods.
It can be used directly with the "--auth-method simple" option or as automatic fallback if NTLM auth fails.
It uses the ldap3 "Connection" class just like the other auth methods.
This can be useful when neither Kerberos nor NTLM protocols are available (rare but possible).
Documentation may need to be updated to show the new option for "--auth-method".