### PR TITLE
Add ForceChangePassword rights for computer accounts

### DIFF
--- a/bloodhound/enumeration/acls.py
+++ b/bloodhound/enumeration/acls.py
@@ -188,7 +188,7 @@ def parse_binary_acl(entry, entrytype, acl, objecttype_guid_map):
                     relations.append(build_relation(sid, 'GetChangesAll', '', inherited=is_inherited))
                 if entrytype == 'domain' and has_extended_right(ace_object, EXTRIGHTS_GUID_MAPPING['GetChangesInFilteredSet']):
                     relations.append(build_relation(sid, 'GetChangesInFilteredSet', '', inherited=is_inherited))
-                if entrytype == 'user' and has_extended_right(ace_object, EXTRIGHTS_GUID_MAPPING['UserForceChangePassword']):
+                if entrytype in ['user', 'computer'] and has_extended_right(ace_object, EXTRIGHTS_GUID_MAPPING['UserForceChangePassword']):
                     relations.append(build_relation(sid, 'ForceChangePassword', '', inherited=is_inherited))
 
         if ace_object.ace.AceType == 0x00:


### PR DESCRIPTION
This PR will also add the Edge for `ForceChangePassword` if an object has this privilege on a computer account. Previously only edges for `ForceChangePassword` on user objects were added.

I am not sure if that was intended, but in the case a group or user would have `ForceChangePassword` privileges over a computer account that could have devastating consequences. However, this is probably a rare configuration, but might still be worth to be added, because why not?